### PR TITLE
Make entrypoint idempotent: skip init when server is already configured

### DIFF
--- a/helix-p4d/docker-entrypoint.sh
+++ b/helix-p4d/docker-entrypoint.sh
@@ -19,8 +19,10 @@ if [[ ! -d "${P4_CONF_DIR}" ]]; then
     cp -rf "/etc/perforce"/* "${P4_CONF_DIR}/"
 fi
 # link docker volume directory to default perforce config location
-mv /etc/perforce{,.orig}
-ln -s "${P4_CONF_DIR}" "/etc/perforce"
+if [[ ! -L /etc/perforce ]]; then
+    mv /etc/perforce /etc/perforce.orig
+    ln -s "${P4_CONF_DIR}" "/etc/perforce"
+fi
 
 # set P4CHARSET if unset and server is running in unicode mode
 if [[ "${P4D_USE_UNICODE}" == "true" ]]; then
@@ -39,26 +41,42 @@ if [[ "${INSTALL_SWARM_TRIGGER}" == "true" ]]; then
     fi
 fi
 
-# run in subshell to prevent environment variable changes
-(
-    # during initialization, P4PORT is set to localhost
-    # so no other services can connect remotely
-    # and interfere with initialization process
-    # shellcheck disable=SC2030
-    if [[ "${P4PORT}" == "ssl:"* ]]; then
-        export P4PORT="ssl:localhost:1666"
-    else
-        export P4PORT="localhost:1666"
-    fi
-    # run all scripts from /docker-startup.d
-    for f in /docker-startup.d/*.sh; do
-        bash "${f}" || exit 1
-    done
-)
+# Sentinel: skip init when server is already configured.
+# Without this, every container restart re-runs /docker-startup.d/*.sh,
+# and 50-configure-helix-p4d.sh fails with
+#   "Can't change P4ROOT for existing servers"
+#   "FATAL: Need to be logged in as a superuser"
+# which kills the container and triggers a restart loop.
+P4ROOT="${P4ROOT:-/data/master/root}"
+SERVER_INITIALIZED=0
+if [[ -f "${P4ROOT}/db.config" ]]; then
+    SERVER_INITIALIZED=1
+fi
 
-# make sure p4d is not started after initialization
-echo "Stopping local-only p4d server..."
-gosu perforce p4dctl stop "${P4NAME}" &>/dev/null
+if [[ "${SERVER_INITIALIZED}" -eq 1 ]]; then
+    echo "Server already initialized at ${P4ROOT} — skipping init scripts."
+else
+    # run in subshell to prevent environment variable changes
+    (
+        # during initialization, P4PORT is set to localhost
+        # so no other services can connect remotely
+        # and interfere with initialization process
+        # shellcheck disable=SC2030
+        if [[ "${P4PORT}" == "ssl:"* ]]; then
+            export P4PORT="ssl:localhost:1666"
+        else
+            export P4PORT="localhost:1666"
+        fi
+        # run all scripts from /docker-startup.d
+        for f in /docker-startup.d/*.sh; do
+            bash "${f}" || exit 1
+        done
+    )
+
+    # make sure p4d is not started after initialization
+    echo "Stopping local-only p4d server..."
+    gosu perforce p4dctl stop "${P4NAME}" &>/dev/null || true
+fi
 
 # exec docker command
 exec "$@"


### PR DESCRIPTION
## Summary

The container enters an infinite restart loop on any non-first start. `/docker-entrypoint.sh` unconditionally re-runs `/docker-startup.d/*.sh` on every boot, and `50-configure-helix-p4d.sh` fails on an existing server with:

```
Can't change P4ROOT for existing servers
FATAL: Need to be logged in as a superuser to perform this operation
```

`set -e` kills the entrypoint, the container exits, Docker restarts it, the loop repeats forever — leaving a healthy server data tree with nothing serving it.

## Repro

```bash
docker compose up -d        # first boot: succeeds, server initialized
docker restart perforce     # restart loop: FATAL repeats forever
docker logs perforce        # confirms loop
```

Verified against `hawkmothstudio/helix-p4d:latest` (image ID at time of test serving p4d 2025.1/2761706) on a fresh empty `/data` volume.

## Fix

Add a single sentinel check (`${P4ROOT}/db.config`) before the init scripts loop. If the server is already initialized, skip the init scripts. Three changes total:

1. **Sentinel** — `if [[ -f \"\${P4ROOT}/db.config\" ]]` gates the entire init block.
2. **Symlink guard** — wrap `mv /etc/perforce{,.orig}` + `ln -s` in `if [[ ! -L /etc/perforce ]]` so it can't fail if the symlink already exists (defense-in-depth).
3. **`|| true` on p4dctl stop** — the post-init stop is now a no-op in the skip path, and without this `set -e` would kill the entrypoint before \`exec \"\$@\"\` runs.

## Behavior

| Scenario | Before | After |
|---|---|---|
| First boot, empty volume | init runs, server initialized | init runs, server initialized (unchanged) |
| Restart, existing server | FATAL, restart loop | `Server already initialized — skipping init scripts.`, p4d stays up |

## Files changed

- `helix-p4d/docker-entrypoint.sh` — 39 insertions, 21 deletions