### PR TITLE
feat: Add nano into p4d container

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ If not, Swarm is initialized using provided environment variables.
 
 After the container has been initialized, all modifications to the Swarm configuration should be done by editing the `config.php` (see [official documentation](https://www.perforce.com/manuals/swarm/Content/Swarm/admin.configuration.html)).
 
+#### Text editor
+`vim` is the default text editor in the container, but `nano` is also available and can be used by `p4` by modifying the `P4EDITOR` environment variable:
+```bash
+P4EDITOR=nano p4 typemap
+```
+
 ### TLS support
 ATTENTION: it is highly recommended running Swarm behind a reverse proxy (e.g. httpd or nginx).
 Running Swarm with TLS enabled can interfere with Swarm's P4 client and lead to certain bugs,

--- a/helix-p4d/Dockerfile
+++ b/helix-p4d/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         gosu \
         software-properties-common \
         vim-tiny \
+        nano \
  && update-alternatives --install /usr/bin/editor editor /usr/bin/vi 1000 \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #58 

Installs nano into the p4d container while keeping vim as the default